### PR TITLE
Add roadmap.md and update GEMINI.md rules

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,4 +12,5 @@ Document the network, proxy, server and application layout of the "blueszeppelin
 ## Documentation
 
 - Keep all infos in the README.md
+- Maintain a `roadmap.md` file to track the next 5 tasks and overall progress
 - Add embedded diagramms with plantuml, keep the diagram source in /diagrams

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,30 @@
+# Roadmap
+
+## Next 5 Tasks
+1. [ ] Map the server hardware and OS specifications.
+2. [ ] Document the Apache web server configuration and version.
+3. [ ] Analyze the Podcast Generator 2.6 setup and its PHP environment.
+4. [ ] Identify and document all media storage locations on the primary server.
+5. [ ] Detail the RSS feed generation process within Podcast Generator.
+
+## All Tasks
+1. [ ] Map the server hardware and OS specifications.
+2. [ ] Document the Apache web server configuration and version.
+3. [ ] Analyze the Podcast Generator 2.6 setup and its PHP environment.
+4. [ ] Identify and document all media storage locations on the primary server.
+5. [ ] Detail the RSS feed generation process within Podcast Generator.
+6. [ ] Trace the proxy configuration for feed.blueszeppelin.net.
+7. [ ] Verify the FeedBurner integration and its role in RSS distribution.
+8. [ ] Document the DNS records for blueszeppelin.net and its subdomains.
+9. [ ] Create a PlantUML diagram of the network topology.
+10. [ ] Map the data flow from content upload to RSS distribution.
+11. [ ] Document the backup and recovery procedures for the podcast media and database.
+12. [ ] Analyze the security measures implemented on the server (firewalls, SSL).
+13. [ ] Document the integration with Apple Podcasts and other directories.
+14. [ ] Identify any external dependencies or third-party services used.
+15. [ ] Create a detailed map of the `/podcast/media/` directory structure.
+16. [ ] Document the process for updating Podcast Generator and its plugins.
+17. [ ] Map the links and redirects from the main website (blueszeppelin.net).
+18. [ ] Document any automated scripts or cron jobs running on the server.
+19. [ ] Create a PlantUML diagram of the application layer architecture.
+20. [ ] Finalize and review the comprehensive documentation in README.md.


### PR DESCRIPTION
This change introduces a `roadmap.md` file to track the progress of the blueszeppelin.net documentation project. It includes an initial set of 20 tasks and a "Next 5 Tasks" section for immediate focus. Additionally, `GEMINI.md` has been updated to include a rule requiring the maintenance of this roadmap.

Fixes #2

---
*PR created automatically by Jules for task [8940378177187533975](https://jules.google.com/task/8940378177187533975) started by @chatelao*